### PR TITLE
Use a macro variable for the circle diameter.

### DIFF
--- a/fluorescence/SetArea_Measure_UserConfirm.ijm
+++ b/fluorescence/SetArea_Measure_UserConfirm.ijm
@@ -17,8 +17,9 @@ for (i = 0; i < lengthOf(files); i++) {
 			makeRectangle(125, 125, 250, 250);
 			run("To Selection");
 				
-			//Prepare selection: a circle with a diameter of 13
-			makeOval(250, 250, 13, 13);
+			//Prepare selection: a circle with default diameter
+			defaultDiameter = 13; 
+			makeOval(250, 250, defaultDiameter, defaultDiameter);
 			
 			//Ask the user to select cell location. The size of the circle should not change
 			waitForUser("Select cell location with pre-defined circle");
@@ -36,7 +37,7 @@ for (i = 0; i < lengthOf(files); i++) {
 			//Measure the fluorescence at the location of the cell
 			makeRectangle(125, 125, 250, 250);
 			run("To Selection");	
-			makeOval(x, y, 13, 13);
+			makeOval(x, y, defaultDiameter, defaultDiameter);
 			waitForUser("Confirm");
 			getStatistics(area, mean, min, max, std);
 			setResult("area", row, area);
@@ -48,7 +49,7 @@ for (i = 0; i < lengthOf(files); i++) {
 			//Measure the background (bg) fluorescence in a different location
 			makeRectangle(125, 125, 250, 250);
 			run("To Selection");	
-			makeOval(x-50, y+50, 13, 13);
+			makeOval(x-50, y+50, defaultDiameter, defaultDiameter);
 			waitForUser("Confirm");
 			getSelectionBounds(s,t, wid, hei);
 			setResult("bg_coord_ch2_x", row, s);
@@ -66,7 +67,7 @@ for (i = 0; i < lengthOf(files); i++) {
 			open(directory + "/" + substring(files[i], 0, 16) + "_Red.C01");
 			makeRectangle(125, 125, 250, 250);
 			run("To Selection");
-			makeOval(x, y, 13, 13);
+			makeOval(x, y, defaultDiameter, defaultDiameter);
 			waitForUser("Confirm");
 			getStatistics(area, mean, min, max, std);
 			setResult("area_h3", row, area);
@@ -76,7 +77,7 @@ for (i = 0; i < lengthOf(files); i++) {
 			setResult("max_ch3", row, max);
 			makeRectangle(125, 125, 250, 250);
 			run("To Selection");
-			makeOval(x-50, y+50, 13, 13);
+			makeOval(x-50, y+50, defaultDiameter, defaultDiameter);
 			waitForUser("Confirm");
 			getSelectionBounds(s, t, wid, hei);
 			setResult("bg_coord_ch3_x", row, s);


### PR DESCRIPTION
Default is kept at 13, but in my experience 30 is sometimes better
when there are big, comma-shaped cells.  Using a variable makes it
easier to edit the macro to change the diameter.
